### PR TITLE
Adds Game Boy Camera resolution of 128x112 pixels.

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,6 +2,7 @@
 <resources>
 	<string name="pref_resolution_default">320x200</string>
     <string-array name="pref_resolution_labels">
+	    <item>128x112</item>
 	    <item>160x120</item>
 	    <item>256x224</item>
 	    <item>320x200</item>
@@ -10,6 +11,7 @@
         <item>960x720</item>
 	</string-array>
     <string-array name="pref_resolution_values">
+	<item>128x112</item>
         <item>160x120</item>
 		<item>256x224</item>
         <item>320x200</item>


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Game_Boy_Camera.

(I also notice a discrepancy with the entry 480x320 vs. 480x360; might be worth fixing, but since I don't know what was intended...)